### PR TITLE
[MZO-46] AppPortal 공용 모듈 설계 및 제작

### DIFF
--- a/src/app/template.tsx
+++ b/src/app/template.tsx
@@ -3,6 +3,8 @@
 import dynamic from 'next/dynamic';
 import { useEffect, useState } from 'react';
 
+import AppPortal from '@/components/app-portal';
+
 const YoutubePlayerController = dynamic(
   () => import('@/components/youtube-player'),
   {
@@ -12,11 +14,15 @@ const YoutubePlayerController = dynamic(
 
 export default function Template({ children }: { children: React.ReactNode }) {
   const [isRendered, setIsRendered] = useState(false);
+
   useEffect(() => setIsRendered(true), []);
+
   return (
-    <div>
-      {isRendered ? <YoutubePlayerController /> : null}
-      {children}
-    </div>
+    <>
+      <AppPortal.Provider portalName="player-portal">
+          {isRendered ? <YoutubePlayerController /> : null}
+          {children}
+      </AppPortal.Provider>
+    </>
   );
 }

--- a/src/app/template.tsx
+++ b/src/app/template.tsx
@@ -20,8 +20,15 @@ export default function Template({ children }: { children: React.ReactNode }) {
   return (
     <>
       <AppPortal.Provider portalName="player-portal">
-          {isRendered ? <YoutubePlayerController /> : null}
+        {isRendered ? <YoutubePlayerController /> : null}
+        <AppPortal.Provider portalName="modal-portal">
+          <AppPortal.Wrapper portalName="modal-portal">
+            <div className="z-10">
+              <p>test another portal</p>
+            </div>
+          </AppPortal.Wrapper>
           {children}
+        </AppPortal.Provider>
       </AppPortal.Provider>
     </>
   );

--- a/src/components/app-portal/AppPortal.tsx
+++ b/src/components/app-portal/AppPortal.tsx
@@ -1,4 +1,4 @@
-'use client'
+'use client';
 
 import { createContext, useContext, useState } from 'react';
 import type { PropsWithChildren, ReactNode } from 'react';
@@ -10,7 +10,9 @@ interface PortalProviderProps {
   portalName?: string | undefined;
 }
 
-const PortalContext = createContext<HTMLDivElement | null>(null);
+const PortalContext = createContext<Map<string, HTMLDivElement | null>>(
+  new Map(),
+);
 
 const PortalProvider = ({
   children,
@@ -20,8 +22,13 @@ const PortalProvider = ({
     null,
   );
 
+  const portalList = useContext(PortalContext);
+  if (portalContainer) {
+    portalList.set(portalName, portalContainer);
+  }
+
   return (
-    <PortalContext.Provider value={portalContainer}>
+    <PortalContext.Provider value={portalList}>
       <div
         id={portalName}
         ref={(element) => {
@@ -33,8 +40,13 @@ const PortalProvider = ({
   );
 };
 
-const PortalWrapper = ({ children }: PropsWithChildren) => {
-  const portalContainer = useContext(PortalContext);
+const PortalWrapper = ({
+  children,
+  portalName = 'app-portal',
+}: PortalProviderProps) => {
+  const portalList = useContext(PortalContext);
+  console.log(portalList);
+  const portalContainer = portalList.get(portalName);
   return portalContainer ? createPortal(children, portalContainer) : null;
 };
 

--- a/src/components/app-portal/AppPortal.tsx
+++ b/src/components/app-portal/AppPortal.tsx
@@ -1,0 +1,35 @@
+import { createContext, useContext, useRef } from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
+
+import { createPortal } from 'react-dom';
+
+const PortalContext = createContext<HTMLDivElement | undefined>(undefined);
+
+interface PortalProviderProps {
+  children: ReactNode;
+  portalName: string | undefined;
+}
+
+const PortalProvider = ({
+  children,
+  portalName = 'app-portal',
+}: PortalProviderProps) => {
+  const portalRef = useRef<HTMLDivElement>();
+  <PortalContext.Provider value={portalRef.current}>
+    <div
+      id={portalName}
+      ref={(element) => {
+        if (element) portalRef.current = element;
+      }}
+    >
+      {children}
+    </div>
+  </PortalContext.Provider>;
+};
+
+const PortalWrapper = ({ children }: PropsWithChildren) => {
+  const portalRef = useContext(PortalContext);
+  return portalRef ? createPortal(children, portalRef) : null;
+};
+
+export { PortalProvider, PortalWrapper };

--- a/src/components/app-portal/AppPortal.tsx
+++ b/src/components/app-portal/AppPortal.tsx
@@ -1,11 +1,13 @@
-import { createContext, useContext, useRef } from 'react';
+'use client'
+
+import { createContext, useContext, useState } from 'react';
 import type { PropsWithChildren, ReactNode } from 'react';
 
 import { createPortal } from 'react-dom';
 
 interface PortalProviderProps {
   children: ReactNode;
-  portalName: string | undefined;
+  portalName?: string | undefined;
 }
 
 const PortalContext = createContext<HTMLDivElement | null>(null);
@@ -14,25 +16,26 @@ const PortalProvider = ({
   children,
   portalName = 'app-portal',
 }: PortalProviderProps) => {
-  const portalRef = useRef<HTMLDivElement | null>(null);
+  const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(
+    null,
+  );
 
   return (
-    <PortalContext.Provider value={portalRef.current}>
+    <PortalContext.Provider value={portalContainer}>
       <div
         id={portalName}
         ref={(element) => {
-          if (element && !portalRef.current) portalRef.current = element; // NOTE : PortalRef가 미설정되었으며 DOM 요소가 잡힐 경우 등록
+          if (element && !portalContainer) setPortalContainer(element);
         }}
-      >
-        {children}
-      </div>
+      />
+      {children}
     </PortalContext.Provider>
   );
 };
 
 const PortalWrapper = ({ children }: PropsWithChildren) => {
-  const portalRef = useContext(PortalContext);
-  return portalRef ? createPortal(children, portalRef) : null;
+  const portalContainer = useContext(PortalContext);
+  return portalContainer ? createPortal(children, portalContainer) : null;
 };
 
 const AppPortal = {

--- a/src/components/app-portal/AppPortal.tsx
+++ b/src/components/app-portal/AppPortal.tsx
@@ -11,7 +11,7 @@ interface PortalProviderProps {
 }
 
 const PortalContext = createContext<Map<string, HTMLDivElement | null>>(
-  new Map(),
+  new Map([]),
 );
 
 const PortalProvider = ({
@@ -45,7 +45,6 @@ const PortalWrapper = ({
   portalName = 'app-portal',
 }: PortalProviderProps) => {
   const portalList = useContext(PortalContext);
-  console.log(portalList);
   const portalContainer = portalList.get(portalName);
   return portalContainer ? createPortal(children, portalContainer) : null;
 };

--- a/src/components/app-portal/AppPortal.tsx
+++ b/src/components/app-portal/AppPortal.tsx
@@ -15,16 +15,19 @@ const PortalProvider = ({
   portalName = 'app-portal',
 }: PortalProviderProps) => {
   const portalRef = useRef<HTMLDivElement | null>(null);
-  <PortalContext.Provider value={portalRef.current}>
-    <div
-      id={portalName}
-      ref={(element) => {
-        if (element && !portalRef.current) portalRef.current = element; // NOTE : PortalRef가 미설정되었으며 DOM 요소가 잡힐 경우 등록
-      }}
-    >
-      {children}
-    </div>
-  </PortalContext.Provider>;
+
+  return (
+    <PortalContext.Provider value={portalRef.current}>
+      <div
+        id={portalName}
+        ref={(element) => {
+          if (element && !portalRef.current) portalRef.current = element; // NOTE : PortalRef가 미설정되었으며 DOM 요소가 잡힐 경우 등록
+        }}
+      >
+        {children}
+      </div>
+    </PortalContext.Provider>
+  );
 };
 
 const PortalWrapper = ({ children }: PropsWithChildren) => {
@@ -33,8 +36,8 @@ const PortalWrapper = ({ children }: PropsWithChildren) => {
 };
 
 const AppPortal = {
-    Provider: PortalProvider,
-    Wrapper: PortalWrapper,
-}
+  Provider: PortalProvider,
+  Wrapper: PortalWrapper,
+};
 
 export default AppPortal;

--- a/src/components/app-portal/AppPortal.tsx
+++ b/src/components/app-portal/AppPortal.tsx
@@ -3,23 +3,23 @@ import type { PropsWithChildren, ReactNode } from 'react';
 
 import { createPortal } from 'react-dom';
 
-const PortalContext = createContext<HTMLDivElement | undefined>(undefined);
-
 interface PortalProviderProps {
   children: ReactNode;
   portalName: string | undefined;
 }
 
+const PortalContext = createContext<HTMLDivElement | null>(null);
+
 const PortalProvider = ({
   children,
   portalName = 'app-portal',
 }: PortalProviderProps) => {
-  const portalRef = useRef<HTMLDivElement>();
+  const portalRef = useRef<HTMLDivElement | null>(null);
   <PortalContext.Provider value={portalRef.current}>
     <div
       id={portalName}
       ref={(element) => {
-        if (element) portalRef.current = element;
+        if (element && !portalRef.current) portalRef.current = element; // NOTE : PortalRef가 미설정되었으며 DOM 요소가 잡힐 경우 등록
       }}
     >
       {children}
@@ -32,4 +32,9 @@ const PortalWrapper = ({ children }: PropsWithChildren) => {
   return portalRef ? createPortal(children, portalRef) : null;
 };
 
-export { PortalProvider, PortalWrapper };
+const AppPortal = {
+    Provider: PortalProvider,
+    Wrapper: PortalWrapper,
+}
+
+export default AppPortal;

--- a/src/components/app-portal/index.ts
+++ b/src/components/app-portal/index.ts
@@ -1,0 +1,3 @@
+import AppPortal from "./AppPortal";
+
+export default AppPortal;

--- a/src/components/youtube-player/YoutubePlayerController.tsx
+++ b/src/components/youtube-player/YoutubePlayerController.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import ReactPlayer from 'react-player/youtube';
 
+import AppPortal from '@/components/app-portal';
 import {
   controlCurrentDurationAtom,
   controlCurrentPlayingAtom,
@@ -76,66 +77,68 @@ const YoutubePlayerController = () => {
   };
 
   return (
-    <div className="flex flex-col">
-      <YoutubePlayer />
-      <div className="flex justify-content-">
-        <button onClick={() => handlePlay('start')}>click to play</button>
-        <button onClick={() => handlePlay('stop')}>click to stop</button>
-      </div>
-      <div className="flex flex-col">
-        <h5>Change Volume</h5>
-        <input
-          type="range"
-          max={1}
-          min={0}
-          step={0.01}
-          value={volume}
-          onChange={handleVolumeRange}
-          disabled={!isPlayerEnabled}
-        />
-      </div>
-      <div className="flex flex-col">
-        <input value={songVid} onChange={handleVidInput} />
-        <button onClick={addNewSongVidInput}>Add Song Vid</button>
-      </div>
-      <div className="flex flex-col">
-        <h5>{`Change Seek Range (${FormatUtil.formatTimeToMMSS(
-          currentDuration,
-        )} : ${FormatUtil.formatTimeToMMSS(
-          playerInstance?.getDuration() || 0,
-        )})`}</h5>
-        <input
-          type="range"
-          max={playerInstance?.getDuration() || 0}
-          min={0}
-          step={1}
-          value={currentDuration}
-          onChange={handleDurationRange}
-          disabled={!isPlayerEnabled}
-        />
-      </div>
-      {playList.length > 0 && (
-        <div className="flex flex-col">
-          <h5>Current Playlist</h5>
-          {playList.map((songVid) => (
-            <p key={songVid}>{songVid}</p>
-          ))}
-          <h5>Current Playing Vid</h5>
-
-          <p>
-            {playList[currentPlayIndex]}
-            {`(${currentPlayIndex} 번)`}
-          </p>
-          {playList.length > 1 && (
-            <>
-              <h5>Change Play Index</h5>
-              <input value={playIndex} onChange={handlePlayIndexInput} />
-              <button onClick={applyPlayIndex}>Change Play Song</button>
-            </>
-          )}
+    <AppPortal.Wrapper>
+      <div className="flex flex-col z-10 fixed left-0 top-0 block container ">
+        <YoutubePlayer />
+        <div className="flex justify-content-">
+          <button onClick={() => handlePlay('start')}>click to play</button>
+          <button onClick={() => handlePlay('stop')}>click to stop</button>
         </div>
-      )}
-    </div>
+        <div className="flex flex-col">
+          <h5>Change Volume</h5>
+          <input
+            type="range"
+            max={1}
+            min={0}
+            step={0.01}
+            value={volume}
+            onChange={handleVolumeRange}
+            disabled={!isPlayerEnabled}
+          />
+        </div>
+        <div className="flex flex-col">
+          <input value={songVid} onChange={handleVidInput} />
+          <button onClick={addNewSongVidInput}>Add Song Vid</button>
+        </div>
+        <div className="flex flex-col">
+          <h5>{`Change Seek Range (${FormatUtil.formatTimeToMMSS(
+            currentDuration,
+          )} : ${FormatUtil.formatTimeToMMSS(
+            playerInstance?.getDuration() || 0,
+          )})`}</h5>
+          <input
+            type="range"
+            max={playerInstance?.getDuration() || 0}
+            min={0}
+            step={1}
+            value={currentDuration}
+            onChange={handleDurationRange}
+            disabled={!isPlayerEnabled}
+          />
+        </div>
+        {playList.length > 0 && (
+          <div className="flex flex-col">
+            <h5>Current Playlist</h5>
+            {playList.map((songVid) => (
+              <p key={songVid}>{songVid}</p>
+            ))}
+            <h5>Current Playing Vid</h5>
+
+            <p>
+              {playList[currentPlayIndex]}
+              {`(${currentPlayIndex} 번)`}
+            </p>
+            {playList.length > 1 && (
+              <>
+                <h5>Change Play Index</h5>
+                <input value={playIndex} onChange={handlePlayIndexInput} />
+                <button onClick={applyPlayIndex}>Change Play Song</button>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    </AppPortal.Wrapper>
   );
 };
 

--- a/src/components/youtube-player/YoutubePlayerController.tsx
+++ b/src/components/youtube-player/YoutubePlayerController.tsx
@@ -77,7 +77,7 @@ const YoutubePlayerController = () => {
   };
 
   return (
-    <AppPortal.Wrapper>
+    <AppPortal.Wrapper portalName="player-portal">
       <div className="flex flex-col z-10 fixed left-0 top-0 block container ">
         <YoutubePlayer />
         <div className="flex justify-content-">


### PR DESCRIPTION
## Jira Issue 번호
#46

## 작업 내용
- Portal의 기반이 되는 DOM을 제공하는 Provider와 Portal을 생성하는 Wrapper로 이루어진 `AppPortal` 모듈을 제작했습니다.
- 상위 Context 에서는 각 Portal의 이름과  Container (DOM) 을 1:1로 매핑한 Map을 보관하도록 했습니다.
- Wrapper 에서는 Provider 단에서 정의한 Portal 이름을 가지고 Container를 찾아내어 새로운 포탈을 생성하도록 했습니다.

## 알리는 내용
- 현재 서비스에서는 Modal 뿐만 아니라 하단 플레이어 바, Toast UI 등 Portal을 소비하는 요소가 많다고 판단했습니다.
- 따라서 각각의 UI를 각기 다른 계층에 놓고, 이를 개별적인 Portal로 관리하면 더욱 좋을 것 같다는 생각을 하였습니다.
- 결론적으로 최상위 Context 에서는 Portal 생성에 필요한 Container를 보관하고, 하위 요소에서는 Wrapper를 통해 어떤 Container를 가지고 Portal을 만들지를 결정하는 형식으로 모듈을 생성하였습니다.

## 사용 방법

```ts
// 1. Provider를 주입하는 방법
// 컴포넌트 내에서 Provider를 감싸고, Portal Container의 Id를 지정합니다.
  return (
    <>
      <AppPortal.Provider portalName="player-portal">
        {isRendered ? <YoutubePlayerController /> : null}
          {children}
      </AppPortal.Provider>
    </>
  );
}

// 2. Wrapper를 통해 특정 Portal Container로부터 portal을 생성하는 방법
// 어떤 portal Container를 기반으로 DOM을 렌더링할지는 portalName props로 지정해주면 됩니다.

  return (
    <AppPortal.Wrapper portalName="player-portal">
      <div className="flex flex-col z-10 fixed left-0 top-0 block container ">
      /** 이하 생략.. */
    </AppPortal.Wrapper>
  );
};
```


## Checklist

- [x] Code Review 요청
- [x] PR 제목 commit convention에 맞는지 확인
- [x] Label 설정
- [x] Jira 코드 리뷰 상태로 변경
