### PR TITLE
[MZO-57] Toast 관련 리팩토링

### DIFF
--- a/src/app/playing/page.tsx
+++ b/src/app/playing/page.tsx
@@ -12,8 +12,8 @@ import PreviousButton from '@/components/header/PreviousButton';
 import EmojiVoteList from '@/domains/playing/emoji-list';
 import PlayController from '@/domains/playing/play-controller';
 import VinylRecordList from '@/domains/playing/vinyl-record';
+import { useToast } from '@/hooks/useToast';
 import { controlOpenEmojiPickerAtom } from '@/stores/emoji-picker';
-import { useToastAtom } from '@/stores/toast';
 
 const YoutubePlayer = dynamic(
   () => import('@/components/youtube-player/YoutubePlayer'),
@@ -23,7 +23,7 @@ const YoutubePlayer = dynamic(
 );
 
 const PlayingPage = () => {
-  const addToast = useSetAtom(useToastAtom);
+  const { toast } = useToast();
   const [isEmojiPickerOpen, setIsEmojiPickerOpen] = useAtom(
     controlOpenEmojiPickerAtom,
   );
@@ -34,7 +34,7 @@ const PlayingPage = () => {
 
   // NOTE: 임시 토스트 테스트용
   const toastTest = () => {
-    addToast('success')('title', 'message');
+    toast.success({ title: 'temp title', message: 'temp message' });
   };
 
   return (

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,0 +1,14 @@
+import { useSetAtom } from 'jotai';
+
+import { useToastAtom } from '@/stores/toast';
+
+export const useToast = () => {
+  const addToast = useSetAtom(useToastAtom);
+  return {
+    toast: {
+      success: addToast('success'),
+      info: addToast('info'),
+      error: addToast('error'),
+    },
+  };
+};

--- a/src/stores/toast/actions.ts
+++ b/src/stores/toast/actions.ts
@@ -5,21 +5,22 @@ import { ToastType } from '@/types/atom';
 
 export const useToastAtom = atom(
   (get) => get(toasterAtom).toasts,
-  (get, set, type: ToastType) => (title: string, message: string) => {
-    const prevAtom = get(toasterAtom);
-    set(toasterAtom, {
-      toasts: [
-        {
-          type,
-          title,
-          message,
-          id: prevAtom.sequence.toString(),
-        },
-        ...prevAtom.toasts,
-      ],
-      sequence: prevAtom.sequence + 1,
-    });
-  },
+  (get, set, type: ToastType) =>
+    ({ title, message }: { title: string; message: string }) => {
+      const prevAtom = get(toasterAtom);
+      set(toasterAtom, {
+        toasts: [
+          {
+            type,
+            title,
+            message,
+            id: prevAtom.sequence.toString(),
+          },
+          ...prevAtom.toasts,
+        ],
+        sequence: prevAtom.sequence + 1,
+      });
+    },
 );
 
 export const removeToastAtom = atom(


### PR DESCRIPTION
## Jira Issue 번호
#57

## 작업 내용
- 기존에는 사용자가(View) store의 action에서 정의한 코드를 사용해야 했습니다. 이렇게 할 경우 해당 로직을 어떻게 써야 하는지 알아야 하는 불편함이 존재했습니다. useToast 커스텀 훅을 만들어 toast를 사용할 때 직관적으로 사용할 수 있게 리팩토링하였습니다.
- 기존에는 props를 (title, message)로 주어 사용자가 순서를 알아야 하는 불편함이 있었습니다. 이를 객체로 바꿔 순서를 몰라도 되도록 수정하였습니다.
- 사용 예시는 아래와 같습니다.
```js
import { useToast } from '@/hooks/useToast'; 

...
const { toast } = useToast();
toast.success({ title, message });
```

## Checklist

- [x] Code Review 요청
- [x] PR 제목 commit convention에 맞는지 확인
- [x] Label 설정
- [x] Jira 코드 리뷰 상태로 변경
